### PR TITLE
[1.19] Crescent Hammer Denylist Config

### DIFF
--- a/src/main/java/cofh/thermal/core/config/ThermalCoreConfig.java
+++ b/src/main/java/cofh/thermal/core/config/ThermalCoreConfig.java
@@ -3,6 +3,7 @@ package cofh.thermal.core.config;
 import cofh.core.config.IBaseConfig;
 import cofh.thermal.core.ThermalCore;
 import cofh.thermal.core.item.SatchelItem;
+import cofh.thermal.core.item.WrenchItem;
 import cofh.thermal.lib.util.ThermalEnergyHelper;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.common.ForgeConfigSpec;
@@ -88,6 +89,18 @@ public class ThermalCoreConfig implements IBaseConfig {
                 .comment("A list of Items by Resource Location which are NOT allowed in Satchels.")
                 .define("Denylist", new ArrayList<>(Arrays.asList(shulkerBoxes)));
 
+        builder.pop();
+
+        builder.push("CrescentHammer");
+
+        String[] wrenchBanList = new String[]{
+                "create:belt",
+        };
+
+        listWrenchBans = builder
+                .comment("A list of Blocks by Resource Location which are NOT allowed to be wrenched by the Crescent Hammer")
+                .define("Denylist", new ArrayList<>(Arrays.asList(wrenchBanList)));
+
         builder.pop(2);
 
         builder.push("Mobs");
@@ -149,6 +162,7 @@ public class ThermalCoreConfig implements IBaseConfig {
         setFlag(FLAG_XP_STORAGE_AUGMENT, !defaultXPStorage.get());
 
         SatchelItem.setBannedItems(listSatchelBans.get());
+        WrenchItem.setBannedBlocks(listWrenchBans.get());
     }
 
     // region VARIABLES
@@ -187,5 +201,8 @@ public class ThermalCoreConfig implements IBaseConfig {
     private Supplier<Boolean> boolStandaloneRedstoneFlux = FALSE;
 
     private Supplier<List<String>> listSatchelBans = Collections::emptyList;
+
+    private Supplier<List<String>> listWrenchBans = Collections::emptyList;
+
     // endregion
 }


### PR DESCRIPTION
Hi there,
When playing with the Create mod I noticed an issue where using the crescent hammer on the conveyer belts from that mod could cause a duplication bug. Here is a linked issue from their Github which shows this. https://github.com/Creators-of-Create/Create/issues/4119
I looked into the thermal config to see if there was any way of blacklisting the belts from being interacted with, and didn't see there were any so I thought I'd give it a go myself. I also thought it would be a useful feature in the event this happens in future with other mods or if pack developers want control over this. I tried to keep the implementation as similar as possible to how the Satchel blacklist is handled for consistency. I added the create belt as a default value for this config.
Thanks for the amazing mods.