### PR TITLE
Make all recipe managers constructors protected so they can be extended by addons

### DIFF
--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/CompressionFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/CompressionFuelManager.java
@@ -17,7 +17,7 @@ public class CompressionFuelManager extends SingleFluidFuelManager {
         return INSTANCE;
     }
 
-    private CompressionFuelManager() {
+    protected CompressionFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/DisenchantmentFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/DisenchantmentFuelManager.java
@@ -36,7 +36,7 @@ public class DisenchantmentFuelManager extends SingleItemFuelManager {
         return INSTANCE;
     }
 
-    private DisenchantmentFuelManager() {
+    protected DisenchantmentFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/GourmandFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/GourmandFuelManager.java
@@ -36,7 +36,7 @@ public class GourmandFuelManager extends SingleItemFuelManager {
         return INSTANCE;
     }
 
-    private GourmandFuelManager() {
+    protected GourmandFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/LapidaryFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/LapidaryFuelManager.java
@@ -17,7 +17,7 @@ public class LapidaryFuelManager extends SingleItemFuelManager {
         return INSTANCE;
     }
 
-    private LapidaryFuelManager() {
+    protected LapidaryFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/MagmaticFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/MagmaticFuelManager.java
@@ -17,7 +17,7 @@ public class MagmaticFuelManager extends SingleFluidFuelManager {
         return INSTANCE;
     }
 
-    private MagmaticFuelManager() {
+    protected MagmaticFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/NumismaticFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/NumismaticFuelManager.java
@@ -17,7 +17,7 @@ public class NumismaticFuelManager extends SingleItemFuelManager {
         return INSTANCE;
     }
 
-    private NumismaticFuelManager() {
+    protected NumismaticFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/dynamo/StirlingFuelManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/dynamo/StirlingFuelManager.java
@@ -34,7 +34,7 @@ public class StirlingFuelManager extends SingleItemFuelManager {
         return INSTANCE;
     }
 
-    private StirlingFuelManager() {
+    protected StirlingFuelManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/BottlerRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/BottlerRecipeManager.java
@@ -65,7 +65,7 @@ public class BottlerRecipeManager extends AbstractManager implements IRecipeMana
         return INSTANCE;
     }
 
-    private BottlerRecipeManager() {
+    protected BottlerRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxOutputItems = 1;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/BrewerRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/BrewerRecipeManager.java
@@ -53,7 +53,7 @@ public class BrewerRecipeManager extends AbstractManager implements IRecipeManag
         return INSTANCE;
     }
 
-    private BrewerRecipeManager() {
+    protected BrewerRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxOutputItems = 0;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/CentrifugeRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/CentrifugeRecipeManager.java
@@ -15,7 +15,7 @@ public class CentrifugeRecipeManager extends SingleItemRecipeManager {
         return INSTANCE;
     }
 
-    private CentrifugeRecipeManager() {
+    protected CentrifugeRecipeManager() {
 
         super(DEFAULT_ENERGY, 4, 1);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/ChillerRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/ChillerRecipeManager.java
@@ -40,7 +40,7 @@ public class ChillerRecipeManager extends AbstractManager implements IRecipeMana
         return INSTANCE;
     }
 
-    private ChillerRecipeManager() {
+    protected ChillerRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxOutputItems = 1;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/CrafterRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/CrafterRecipeManager.java
@@ -24,7 +24,7 @@ public class CrafterRecipeManager extends AbstractManager implements IManager {
         return INSTANCE;
     }
 
-    private CrafterRecipeManager() {
+    protected CrafterRecipeManager() {
 
         super(DEFAULT_ENERGY);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/CrucibleRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/CrucibleRecipeManager.java
@@ -15,7 +15,7 @@ public class CrucibleRecipeManager extends SingleItemRecipeManager {
         return INSTANCE;
     }
 
-    private CrucibleRecipeManager() {
+    protected CrucibleRecipeManager() {
 
         super(DEFAULT_ENERGY, 0, 1);
         this.basePower = 80;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/CrystallizerRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/CrystallizerRecipeManager.java
@@ -41,7 +41,7 @@ public class CrystallizerRecipeManager extends AbstractManager implements IRecip
         return INSTANCE;
     }
 
-    private CrystallizerRecipeManager() {
+    protected CrystallizerRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxInputItems = 2;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/FurnaceRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/FurnaceRecipeManager.java
@@ -29,7 +29,7 @@ public class FurnaceRecipeManager extends SingleItemRecipeManager {
         return INSTANCE;
     }
 
-    private FurnaceRecipeManager() {
+    protected FurnaceRecipeManager() {
 
         super(DEFAULT_ENERGY, 1, 0);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/InsolatorRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/InsolatorRecipeManager.java
@@ -28,7 +28,7 @@ public class InsolatorRecipeManager extends SingleItemRecipeManager.Catalyzed {
         return INSTANCE;
     }
 
-    private InsolatorRecipeManager() {
+    protected InsolatorRecipeManager() {
 
         super(DEFAULT_ENERGY, 4, 0);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/PressRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/PressRecipeManager.java
@@ -38,7 +38,7 @@ public class PressRecipeManager extends AbstractManager implements IRecipeManage
         return INSTANCE;
     }
 
-    private PressRecipeManager() {
+    protected PressRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxOutputItems = 1;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/PulverizerRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/PulverizerRecipeManager.java
@@ -37,7 +37,7 @@ public class PulverizerRecipeManager extends SingleItemRecipeManager.Catalyzed {
         return INSTANCE;
     }
 
-    private PulverizerRecipeManager() {
+    protected PulverizerRecipeManager() {
 
         super(DEFAULT_ENERGY, 4, 0);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/PyrolyzerRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/PyrolyzerRecipeManager.java
@@ -15,7 +15,7 @@ public class PyrolyzerRecipeManager extends SingleItemRecipeManager {
         return INSTANCE;
     }
 
-    private PyrolyzerRecipeManager() {
+    protected PyrolyzerRecipeManager() {
 
         super(DEFAULT_ENERGY, 4, 1);
         this.basePower = 5;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/RefineryRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/RefineryRecipeManager.java
@@ -37,7 +37,7 @@ public class RefineryRecipeManager extends AbstractManager implements IRecipeMan
         return INSTANCE;
     }
 
-    private RefineryRecipeManager() {
+    protected RefineryRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxOutputItems = 1;

--- a/src/main/java/cofh/thermal/core/util/managers/machine/SawmillRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/SawmillRecipeManager.java
@@ -33,7 +33,7 @@ public class SawmillRecipeManager extends SingleItemRecipeManager {
         return INSTANCE;
     }
 
-    private SawmillRecipeManager() {
+    protected SawmillRecipeManager() {
 
         super(DEFAULT_ENERGY, 4, 0);
     }

--- a/src/main/java/cofh/thermal/core/util/managers/machine/SmelterRecipeManager.java
+++ b/src/main/java/cofh/thermal/core/util/managers/machine/SmelterRecipeManager.java
@@ -52,7 +52,7 @@ public class SmelterRecipeManager extends AbstractManager implements IRecipeMana
         return INSTANCE;
     }
 
-    private SmelterRecipeManager() {
+    protected SmelterRecipeManager() {
 
         super(DEFAULT_ENERGY);
         this.maxInputItems = 3;


### PR DESCRIPTION
<!-- Hi Shiny in the secret GitHub channel -->
At the moment the recipe manager classes are effectively final because subclasses cannot call the super constructor. 

My usecase for this is making a copy of some existing machines but powered in a different way, and having a config option to allow them to use a separate recipe system for pack makers that want to repurpose the machines.

I have not compiled this as I cannot be bothered fighting gradle just to confirm that I didn't mispell protected.